### PR TITLE
feature/class-use-hoisted

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
 		"no-trailing-spaces": "error",
 		"no-undef": "error",
 		"no-underscore-dangle": "off",
-		"no-use-before-define": ["error", "nofunc"],
+		"no-use-before-define": ["error", { "functions": false, "classes": false }]
 		"object-curly-spacing": ["error", "always"],
 		"quotes": ["error", "single", "avoid-escape"],
 		"semi": ["error", "always"],


### PR DESCRIPTION
https://eslint.org/docs/rules/no-use-before-define#classes

this form is no longer an error:

```javascript
function foo(){
    return new A();
}

class A {}
```

but importantly, this still is:

```javascript
new A();
class A {}
```

I ran into this while working on `desktop-ide`. I define a series of errors [here](https://github.com/particle-iot/desktop-ide/blob/ecd11b235c8c81de27a1ece5aa3a5fe2fdd3be8e/packages/particle-vscode-core/src/compiler/dependency-manager.js#L123) but they are thrown [here](https://github.com/particle-iot/desktop-ide/blob/ecd11b235c8c81de27a1ece5aa3a5fe2fdd3be8e/packages/particle-vscode-core/src/compiler/dependency-manager.js#L27). 