### PR TITLE
feature/anon-fns-are-ok-sometimes

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
 		"curly": "error",
 		"eol-last": "error",
 		"eqeqeq": ["error", "smart"],
-		"func-names": "error",
+		"func-names": ["error", "as-needed"],
 		"func-style": ["error", "declaration", { "allowArrowFunctions": true }],
 		"handle-callback-err": "error",
 		"indent": ["error", "tab", {


### PR DESCRIPTION
modern js engines infer function names in many cases. as such, we can safely loosen our naming requirements. 

explanation & examples here:
https://eslint.org/docs/rules/func-names#as-needed