### PR TITLE
Linter config update from API cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,11 @@ eslint config rules for Particle Javascript projects
 
 1. Install dependencies
 `npm install --save-dev eslint eslint-config-particle`
-1. Tell eslint to use the Particle config by creating `.eslintrc`
+1. Tell eslint to use the Particle config by creating `.eslintrc.js`
 ```
-{
-  "extends": "particle",
-  "root": true,
-  "env": {
-    "es6": true,
-    "mocha": true,
-    "node": true
-  }
+module.exports = {
+  extends: ['eslint-config-particle'],
+  root: true
 }
 ```
 1. Add lint scripts to `package.json`

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ module.exports = {
 		"no-undef": "error",
 		"no-underscore-dangle": "off",
 		"no-use-before-define": ["error", { "functions": false, "classes": false }],
+		"no-var": "error",
 		"object-curly-spacing": ["error", "always"],
 		"quotes": ["error", "single", "avoid-escape"],
 		"semi": ["error", "always"],
@@ -52,5 +53,13 @@ module.exports = {
 			"requireReturn": false,
 			"requireParamDescription": false
 		}]
-	}
+	},
+	overrides: [
+		{
+			files: ["*.spec.js", "*.test.js", "*.e2e.js", "*.integration.js"],
+			rules: {
+				"func-names": "off"
+			}
+		}
+	]
 };

--- a/index.js
+++ b/index.js
@@ -1,65 +1,73 @@
 module.exports = {
-	"extends": "eslint:recommended",
-	"rules": {
-		"array-bracket-spacing": ["error", "never"],
-		"block-scoped-var": "error",
-		"brace-style": ["error", "1tbs"],
-		"camelcase": ["error", { "properties": "never" }],
-		"constructor-super": "error",
-		"curly": "error",
-		"eol-last": "error",
-		"eqeqeq": ["error", "smart"],
-		"func-names": ["error", "as-needed"],
-		"func-style": ["error", "declaration", { "allowArrowFunctions": true }],
-		"handle-callback-err": "error",
-		"indent": ["error", "tab", {
-			"SwitchCase": 1,
-			"ObjectExpression": "first",
-		  "MemberExpression": 1
+	extends: 'eslint:recommended',
+	parserOptions: {
+		ecmaVersion: 9
+	},
+	env: {
+		es6: true,
+		node: true,
+		mocha: true
+	},
+	rules: {
+		'array-bracket-spacing': ['error', 'never'],
+		'block-scoped-var': 'error',
+		'brace-style': ['error', '1tbs'],
+		'camelcase': ['error', { 'properties': 'never' }],
+		'constructor-super': 'error',
+		'curly': 'error',
+		'eol-last': 'error',
+		'eqeqeq': ['error', 'smart'],
+		'func-names': ['error', 'as-needed'],
+		'func-style': ['error', 'declaration', { 'allowArrowFunctions': true }],
+		'handle-callback-err': 'error',
+		'indent': ['error', 'tab', {
+			'SwitchCase': 1,
+			'ObjectExpression': 'first',
+		  'MemberExpression': 1
 		}],
-		"keyword-spacing": ["error", {
-		  "before": true,
-		  "after": true,
+		'keyword-spacing': ['error', {
+		  'before': true,
+		  'after': true,
 		}],
-		"max-depth": ["warn", 3],
-		"max-statements": ["warn", 30],
-		"new-cap": "warn",
-		"no-class-assign": "error",
-		"no-cond-assign": ["error", "except-parens"],
-		"no-const-assign": "error",
-		"no-dupe-class-members": "error",
-		"no-extend-native": "error",
-		"no-extra-parens": ["error", "functions"],
-		"no-mixed-spaces-and-tabs": "error",
-		"no-multi-spaces": ["warn", {
-			"exceptions": {
-				"VariableDeclarator": true
+		'max-depth': ['warn', 3],
+		'max-statements': ['warn', 30],
+		'new-cap': 'warn',
+		'no-class-assign': 'error',
+		'no-cond-assign': ['error', 'except-parens'],
+		'no-const-assign': 'error',
+		'no-dupe-class-members': 'error',
+		'no-extend-native': 'error',
+		'no-extra-parens': ['error', 'functions'],
+		'no-mixed-spaces-and-tabs': 'error',
+		'no-multi-spaces': ['warn', {
+			'exceptions': {
+				'VariableDeclarator': true
 			}
 		}],
-		"no-nested-ternary": "error",
-		"no-prototype-builtins": "off",
-		"no-this-before-super": "error",
-		"no-trailing-spaces": "error",
-		"no-undef": "error",
-		"no-underscore-dangle": "off",
-		"no-use-before-define": ["error", { "functions": false, "classes": false }],
-		"no-var": "error",
-		"object-curly-spacing": ["error", "always"],
-		"prefer-const": "error",
-		"quotes": ["error", "single", "avoid-escape"],
-		"semi": ["error", "always"],
-		"space-unary-ops": ["error", {"words": true, "nonwords": false}],
-		"strict": ["error", "global"],
-		"valid-jsdoc": ["warn", {
-			"requireReturn": false,
-			"requireParamDescription": false
+		'no-nested-ternary': 'error',
+		'no-prototype-builtins': 'off',
+		'no-this-before-super': 'error',
+		'no-trailing-spaces': 'error',
+		'no-undef': 'error',
+		'no-underscore-dangle': 'off',
+		'no-use-before-define': ['error', { 'functions': false, 'classes': false }],
+		'no-var': 'error',
+		'object-curly-spacing': ['error', 'always'],
+		'prefer-const': 'error',
+		'quotes': ['error', 'single', 'avoid-escape'],
+		'semi': ['error', 'always'],
+		'space-unary-ops': ['error', {'words': true, 'nonwords': false}],
+		'strict': ['error', 'global'],
+		'valid-jsdoc': ['warn', {
+			'requireReturn': false,
+			'requireParamDescription': false
 		}]
 	},
 	overrides: [
 		{
-			files: ["*.spec.js", "*.test.js", "*.e2e.js", "*.integration.js"],
+			files: ['*.spec.js', '*.test.js', '*.e2e.js', '*.integration.js'],
 			rules: {
-				"func-names": "off"
+				'func-names': 'off'
 			}
 		}
 	]

--- a/index.js
+++ b/index.js
@@ -45,6 +45,7 @@ module.exports = {
 		"no-use-before-define": ["error", { "functions": false, "classes": false }],
 		"no-var": "error",
 		"object-curly-spacing": ["error", "always"],
+		"prefer-const": "error",
 		"quotes": ["error", "single", "avoid-escape"],
 		"semi": ["error", "always"],
 		"space-unary-ops": ["error", {"words": true, "nonwords": false}],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-particle",
-  "version": "2.3.0",
+  "version": "2.4.0-rc.1",
   "description": "eslint config rules for Particle projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Add exception for unnamed functions in test files
- Do not allow use of `var`. Run `npm run lint:fix` to replace `var` with `let` for the whole project.
- Specify language version to use (ECMAscript 9 / 2018)

The goal is that for Node backend projects the `.eslintrc.js` file should be:
```
module.exports = {
	extends: ['eslint-config-particle']
};
```
Front end projects can tweak the `env` with `node: false, browser: true`.