### PR TITLE
Allows template literals for quotes rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ module.exports = {
 		'no-var': 'error',
 		'object-curly-spacing': ['error', 'always'],
 		'prefer-const': 'error',
-		'quotes': ['error', 'single', 'avoid-escape'],
+		'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': true }],
 		'semi': ['error', 'always'],
 		'space-unary-ops': ['error', {'words': true, 'nonwords': false}],
 		'strict': ['error', 'global'],


### PR DESCRIPTION
Any objection to adding _"allowTemplateLiterals": true_ for the _quotes_ rule?

When I [linted Console with `--fix`, the _quotes_ rule did this](https://github.com/particle-iot/console/pull/455/files#diff-78d589369dc89d2445d0633c6d4451beR36):
```diff
-          notify.error(`There was a problem exporting the device's data`);
+          notify.error('There was a problem exporting the device\'s data');
```

I believe the use of a template literal is preferable to an escape sequence.