### PR TITLE
feature/line-length

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,14 @@ module.exports = {
 			after: true,
 		}],
 		'max-depth': ['warn', 3],
+		'max-len': ['error', {
+			code: 120,
+			ignoreComments: true,
+			ignoreTrailingComments: true,
+			ignoreUrls: true,
+			ignoreStrings: true,
+			ignoreTemplateLiterals: true
+		}],
 		'max-statements': ['warn', 30],
 		'new-cap': 'warn',
 		'no-class-assign': 'error',

--- a/index.js
+++ b/index.js
@@ -12,22 +12,26 @@ module.exports = {
 		'array-bracket-spacing': ['error', 'never'],
 		'block-scoped-var': 'error',
 		'brace-style': ['error', '1tbs'],
-		'camelcase': ['error', { 'properties': 'never' }],
+		'camelcase': ['error', {
+			properties: 'never'
+		}],
 		'constructor-super': 'error',
 		'curly': 'error',
 		'eol-last': 'error',
 		'eqeqeq': ['error', 'smart'],
 		'func-names': ['error', 'as-needed'],
-		'func-style': ['error', 'declaration', { 'allowArrowFunctions': true }],
+		'func-style': ['error', 'declaration', {
+			allowArrowFunctions: true
+		}],
 		'handle-callback-err': 'error',
 		'indent': ['error', 'tab', {
-			'SwitchCase': 1,
-			'ObjectExpression': 'first',
-			'MemberExpression': 1
+			SwitchCase: 1,
+			ObjectExpression: 'first',
+			MemberExpression: 1
 		}],
 		'keyword-spacing': ['error', {
-			'before': true,
-			'after': true,
+			before: true,
+			after: true,
 		}],
 		'max-depth': ['warn', 3],
 		'max-statements': ['warn', 30],
@@ -40,8 +44,8 @@ module.exports = {
 		'no-extra-parens': ['error', 'functions'],
 		'no-mixed-spaces-and-tabs': 'error',
 		'no-multi-spaces': ['warn', {
-			'exceptions': {
-				'VariableDeclarator': true
+			exceptions: {
+				VariableDeclarator: true
 			}
 		}],
 		'no-nested-ternary': 'error',
@@ -50,17 +54,26 @@ module.exports = {
 		'no-trailing-spaces': 'error',
 		'no-undef': 'error',
 		'no-underscore-dangle': 'off',
-		'no-use-before-define': ['error', { 'functions': false, 'classes': false }],
+		'no-use-before-define': ['error', {
+			functions: false,
+			classes: false
+		}],
 		'no-var': 'error',
 		'object-curly-spacing': ['error', 'always'],
 		'prefer-const': 'error',
-		'quotes': ['error', 'single', { 'avoidEscape': true, 'allowTemplateLiterals': true }],
+		'quotes': ['error', 'single', {
+			avoidEscape: true,
+			allowTemplateLiterals: true
+		}],
 		'semi': ['error', 'always'],
-		'space-unary-ops': ['error', {'words': true, 'nonwords': false}],
+		'space-unary-ops': ['error', {
+			words: true,
+			nonwords: false
+		}],
 		'strict': ['error', 'global'],
 		'valid-jsdoc': ['warn', {
-			'requireReturn': false,
-			'requireParamDescription': false
+			requireReturn: false,
+			requireParamDescription: false
 		}]
 	},
 	overrides: [

--- a/index.js
+++ b/index.js
@@ -23,11 +23,11 @@ module.exports = {
 		'indent': ['error', 'tab', {
 			'SwitchCase': 1,
 			'ObjectExpression': 'first',
-		  'MemberExpression': 1
+			'MemberExpression': 1
 		}],
 		'keyword-spacing': ['error', {
-		  'before': true,
-		  'after': true,
+			'before': true,
+			'after': true,
 		}],
 		'max-depth': ['warn', 3],
 		'max-statements': ['warn', 30],


### PR DESCRIPTION
very long lines are hard to read so it's pretty common to restrict source code line length to 80cols ([example](https://google.github.io/styleguide/jsguide.html#formatting-column-limit)). this makes lines longer than 120cols an error with exceptions for comments, strings, and template literals.

Rule details here 👉 https://eslint.org/docs/rules/max-len

