### PR TITLE
feature/spacing

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,6 @@ module.exports = {
 			allowTemplateLiterals: true
 		}],
 		'semi': ['error', 'always'],
-		'space-before-blocks': ['error', {
-			functions: 'never',
-			keywords: 'never',
-			classes: 'always'
-		}],
 		'space-in-parens': ['error', 'never'],
 		'space-infix-ops': 'error',
 		'space-unary-ops': ['error', {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ module.exports = {
 	},
 	rules: {
 		'array-bracket-spacing': ['error', 'never'],
+		'arrow-spacing': 'error',
 		'block-scoped-var': 'error',
+		'block-spacing': 'error',
 		'brace-style': ['error', '1tbs'],
 		'camelcase': ['error', {
 			properties: 'never'
@@ -51,9 +53,9 @@ module.exports = {
 		'no-extend-native': 'error',
 		'no-extra-parens': ['error', 'functions'],
 		'no-mixed-spaces-and-tabs': 'error',
-		'no-multi-spaces': ['warn', {
+		'no-multi-spaces': ['error', {
 			exceptions: {
-				VariableDeclarator: true
+				VariableDeclarator: true,
 			}
 		}],
 		'no-nested-ternary': 'error',
@@ -66,6 +68,7 @@ module.exports = {
 			functions: false,
 			classes: false
 		}],
+		'no-whitespace-before-property': 'error',
 		'no-var': 'error',
 		'object-curly-spacing': ['error', 'always'],
 		'prefer-const': 'error',
@@ -74,6 +77,13 @@ module.exports = {
 			allowTemplateLiterals: true
 		}],
 		'semi': ['error', 'always'],
+		'space-before-blocks': ['error', {
+			functions: 'never',
+			keywords: 'never',
+			classes: 'always'
+		}],
+		'space-in-parens': ['error', 'never'],
+		'space-infix-ops': 'error',
 		'space-unary-ops': ['error', {
 			words: true,
 			nonwords: false


### PR DESCRIPTION
adds a series of rules which collectively tighten up spacing / whitespace formatting for our js.

rules added / now errors:
* [arrow-spacing](https://eslint.org/docs/rules/arrow-spacing)
* [block-spacing](https://eslint.org/docs/rules/block-spacing)
* [no-multi-spaces](https://eslint.org/docs/rules/no-multi-spaces) [was a warning, now an error]
* [no-whitespace-before-property](https://eslint.org/docs/rules/no-whitespace-before-property)
* ~[space-before-blocks](https://eslint.org/docs/rules/space-before-blocks)~
* [space-in-parens](https://eslint.org/docs/rules/space-in-parens)
* [space-infix-ops](https://eslint.org/docs/rules/space-infix-ops)

~of these, it seems `space-before-blocks` setting could be the most controversial as it enforces:~ edit: dropped it 🤗 

```js
// error
function foo() {
    //...
}

if (bar) {
    //...
}

// ok
function foo(){
    //...
}

if (bar){
    //...
}
```

i ran the updated settings against a series of our repos (`api-service`, and `device-service` being the largest) and while it produced _a lot_ or errors, all could be automatically fixed (typically via the `npm run lint:fix` command).

